### PR TITLE
CI build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,36 +35,61 @@ jobs:
       - name: Install building requirements
         run: |
           sudo apt-get update && \
-          sudo apt-get install -y \
-            gfortran \
-            libatlas3-base \
-            libblas3 \
-            libblas3gf \
-            libcerf-dev \
-            libgsl0-dbg \
-            liblapack-dev \
-            liblapack3 \
-            liblapack3gf \
-            liblapacke \
-            libnlopt-dev \
-            libopenblas-dev \
-            libtool
+          sudo apt-get install -y tree gfortran # && \
+          # sudo apt-get install -y \
+          #   libatlas3-base \
+          #   libblas3 \
+          #   libblas3gf \
+          #   libcerf-dev \
+          #   libgsl0-dbg \
+          #   liblapack-dev \
+          #   liblapack3 \
+          #   liblapack3gf \
+          #   liblapacke \
+          #   libnlopt-dev \
+          #   libopenblas-dev \
+          #   libtool
 
       - name: Build
         run: |
           set -vxeuo pipefail
+
           cd UNIX/DEBUSSY_v2.2/
           DEBUSSY_SRC_DIR="$PWD"
           DEBUSSY_TARGET_DIR="/tmp/debussy"
 
-          # Build extlib
+          # Build extlib:
           cd extlib/LAPACK95-lite/
           ./doall.sh
           git status
 
-          # Build DEBUSSY
+          # Build DEBUSSY:
           cd ${DEBUSSY_SRC_DIR}
           mkdir -v -p ${DEBUSSY_TARGET_DIR}
-          # Install external libraries LAPACK (link only), LIBCERF, NLOPT (sudo credentials required) [Y / N] :n
-          # Install GUI ("GUI" folder must be in "src" folder) [Y / N] :y
-          echo -e "/tmp/debussy\nn\ny" | ./install_debussy_v2.2
+
+          # Answers to the installation script:
+          #   installation folder is  : /tmp/debussy
+          #   /tmp/debussy/ exists
+          #   /home/vagrant/src/DEBUSSY_v2.2-UNIX/UNIX/DEBUSSY_v2.2/src exists
+          #   /tmp/debussy/lib exists
+          #   /tmp/debussy/incl exists
+          #   /tmp/debussy/bin exists
+
+          #   Install external libraries LAPACK (link only), LIBCERF, NLOPT (sudo credentials required) [Y / N] :
+          #   Install GUI ("GUI" folder must be in "src" folder) [Y / N] :
+          #   ... checking platform : this is a linux-gnu-system
+
+          #   ... current folder is /home/vagrant/src/DEBUSSY_v2.2-UNIX/UNIX/DEBUSSY_v2.2
+          #   Download lapack and blas libraries from system repositories? (an active internet connection is required) [Y / N]... your answer is y
+          #   Downloading lapack and blas libraries from system repositories ...
+          echo -e "/tmp/debussy\ny\ny\ny\n" | ./install_debussy_v2.2
+
+          # Check the resulting files:
+          ls -alF ${DEBUSSY_TARGET_DIR}
+          tree -aF ${DEBUSSY_TARGET_DIR}
+          ldd ${DEBUSSY_TARGET_DIR}/bin/Debussy
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: debussy-build
+          path: /tmp/debussy/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,14 +34,23 @@ jobs:
 
       - name: Install building requirements
         run: |
-          sudo apt-get update && sudo apt-get install -y gfortran-9
-          sudo ln -svf /usr/bin/gfortran-9 /usr/bin/gfortran
+          sudo apt-get update && sudo apt-get install -y gfortran libcerf-dev libnlopt-dev
 
       - name: Build
         run: |
           set -vxeuo pipefail
           cd UNIX/DEBUSSY_v2.2/
-          mkdir -v -p /tmp/debussy/
+          DEBUSSY_SRC_DIR="$PWD"
+          DEBUSSY_TARGET_DIR="/tmp/debussy"
+
+          # Build extlib
+          cd extlib/LAPACK95-lite/
+          ./doall.sh
+          git status
+
+          # Build DEBUSSY
+          cd ${DEBUSSY_SRC_DIR}
+          mkdir -v -p ${DEBUSSY_TARGET_DIR}
           # Install external libraries LAPACK (link only), LIBCERF, NLOPT (sudo credentials required) [Y / N] :n
           # Install GUI ("GUI" folder must be in "src" folder) [Y / N] :y
           echo -e "/tmp/debussy\nn\ny" | ./install_debussy_v2.2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,12 +35,11 @@ jobs:
       - name: Install building requirements
         run: |
           sudo apt-get update && \
-          sudo apt-get install -y tree gfortran # && \
-          # sudo apt-get install -y \
+          sudo apt-get install -y tree gfortran && \
+          sudo apt-get install -y libcerf-dev
           #   libatlas3-base \
           #   libblas3 \
           #   libblas3gf \
-          #   libcerf-dev \
           #   libgsl0-dbg \
           #   liblapack-dev \
           #   liblapack3 \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,21 @@ jobs:
 
       - name: Install building requirements
         run: |
-          sudo apt-get update && sudo apt-get install -y gfortran libcerf-dev libnlopt-dev
+          sudo apt-get update && \
+          sudo apt-get install -y \
+            gfortran \
+            libatlas3-base \
+            libblas3 \
+            libblas3gf \
+            libcerf-dev \
+            libgsl0-dbg \
+            liblapack-dev \
+            liblapack3 \
+            liblapack3gf \
+            liblapacke \
+            libnlopt-dev \
+            libopenblas-dev \
+            libtool
 
       - name: Build
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,5 +91,5 @@ jobs:
 
       - uses: actions/upload-artifact@v3
         with:
-          name: debussy-build
+          name: debussy-build-py${{ matrix.python-version }}
           path: /tmp/debussy/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,6 +88,12 @@ jobs:
           tree -aF ${DEBUSSY_TARGET_DIR}
           ldd ${DEBUSSY_TARGET_DIR}/bin/Debussy
 
+      - name: Testing
+        run: |
+          set -vxeuo pipefail
+          cd UNIX/RUN_TEST_UNIX/
+          echo -e "\n" | bash ./drun
+
       - uses: actions/upload-artifact@v3
         with:
           name: debussy-build-py${{ matrix.python-version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install building requirements
         run: |
           sudo apt-get update && sudo apt-get install -y gfortran-9
-          sudo ln -sv /usr/bin/gfortran-9 /usr/bin/gfortran
+          sudo ln -svf /usr/bin/gfortran-9 /usr/bin/gfortran
 
       - name: Build
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,47 @@
+name: Build
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: '00 4 * * *'  # daily at 4AM
+
+jobs:
+  run_build:
+    # pull requests are a duplicate of a branch push if within the same repo.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
+
+    name: Build DEBUSSY with with Python ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10"]
+      fail-fast: false
+
+    defaults:
+      run:
+        shell: bash -l {0}
+
+    steps:
+      - name: Set env vars
+        run: |
+          export REPOSITORY_NAME=${GITHUB_REPOSITORY#*/}  # just the repo, as opposed to org/repo
+          echo "REPOSITORY_NAME=${REPOSITORY_NAME}" >> $GITHUB_ENV
+
+      - name: Checkout the code
+        uses: actions/checkout@v3
+
+      - name: Install building requirements
+        run: |
+          sudo apt-get update && sudo apt-get install -y gfortran-9
+          sudo ln -sv /usr/bin/gfortran-9 /usr/bin/gfortran
+
+      - name: Build
+        run: |
+          set -vxeuo pipefail
+          cd UNIX/DEBUSSY_v2.2/
+          mkdir -v -p /tmp/debussy/
+          # Install external libraries LAPACK (link only), LIBCERF, NLOPT (sudo credentials required) [Y / N] :n
+          # Install GUI ("GUI" folder must be in "src" folder) [Y / N] :y
+          echo -e "/tmp/debussy\nn\ny" | ./install_debussy_v2.2

--- a/UNIX/DEBUSSY_v2.2/install_debussy_v2.2
+++ b/UNIX/DEBUSSY_v2.2/install_debussy_v2.2
@@ -113,18 +113,20 @@ if [ "$aw1" == "Y" ] || [ "$aw1" == "y" ] && [ "$platform" == "linux-gnu" ] ; th
         echo 'Downloading lapack and blas libraries from system repositories ... '
         echo ' '
         echo 'LAPACK'
-        sudo apt-get install liblapack3gf
-        sudo apt-get install libatlas3-base
-        sudo apt-get install liblapacke
-        sudo apt-get install liblapack3
-        sudo apt-get install liblapack-dev
+        sudo apt-get install -y \
+	  liblapack3gf \
+          libatlas3-base \
+          liblapacke \
+          liblapack3 \
+          liblapack-dev
         echo ' '
         echo 'LIBBLAS'
-        sudo apt-get install libblas3
-        sudo apt-get install libblas3gf
-        sudo apt-get install libopenblas-dev
-        sudo apt-get install libgsl0-dbg
-        sudo apt-get install libtool
+        sudo apt-get install -y \
+          libblas3 \
+          libblas3gf \
+          libopenblas-dev \
+          libgsl0-dbg \
+          libtool
         echo ' '
     fi
 fi


### PR DESCRIPTION
Dear @febertol, here is my draft pull request with the changes to make it work in the cloud with the GitHub Actions workflows. The generated files can be downloaded from this page: https://github.com/mrakitin/DEBUSSY_v2.2-UNIX/actions/runs/5271893967.

A couple of notes regarding the compilation/building:
1. I've noticed I had to pre-install `libcerf` to make the successful compilation as the build of [`DEBUSSY_v2.2/extlib/libcerf-1.5`](https://github.com/DeByeUSerSYstem/DEBUSSY_v2.2-UNIX/tree/main/UNIX/DEBUSSY_v2.2/extlib/libcerf-1.5) fails due to a mismatching `aclocal` version 1.15.
2. There are a couple of missing packages attempted to install via `apt-get` (`E: Unable to locate package liblapack3gf` and `E: Unable to locate package libblas3gf`). Is it something safe to skip?
3. I got all the packages compiled: https://github.com/mrakitin/DEBUSSY_v2.2-UNIX/actions/runs/5271893967/jobs/9533406586#step:5:2247. However, to use the suite, I had to change the paths in https://github.com/DeByeUSerSYstem/DEBUSSY_v2.2-UNIX/blob/df16f370d5105ff87fb9ba8a24eb5ae4ce57e329/UNIX/DEBUSSY_v2.2/MAKING_gfortran/doall_Debussy.sh#L2-L3
and recompile locally.
5. I needed to install `python`, `wxpython`, and `matplotlib` (via conda).
6. After all those changes, the GUI started, but I needed to install `xterm`.

I think some of the questions may be worked around pretty easily in the automated build.

Regarding the testing, I tried to use the [`DEBUSSY_v2.2-UNIX/UNIX/RUN_TEST_UNIX/drun`](https://github.com/DeByeUSerSYstem/DEBUSSY_v2.2-UNIX/blob/main/UNIX/RUN_TEST_UNIX/drun) script, but it failed. What would be a representative test/example to make sure the compilation and configuration are correct?

Thanks a lot!